### PR TITLE
Fix accidentally stop and sluggish response

### DIFF
--- a/ThreeFingerDragOnWindows/utils/StartupManager.cs
+++ b/ThreeFingerDragOnWindows/utils/StartupManager.cs
@@ -23,6 +23,11 @@ public static class StartupManager {
         taskDefinition.RegistrationInfo.Description = "Starting ThreeFingerDragOnWindows on system startup with elevated privileges.";
         taskDefinition.RegistrationInfo.Author = "Clément Grennerat";
         taskDefinition.Principal.RunLevel = TaskRunLevel.Highest;
+        taskDefinition.Settings.DisallowStartIfOnBatteries = false;
+        taskDefinition.Settings.StopIfGoingOnBatteries = false;
+        taskDefinition.Settings.IdleSettings.StopOnIdleEnd = false;
+        taskDefinition.Settings.ExecutionTimeLimit = TimeSpan.Zero;
+        taskDefinition.Settings.AllowHardTerminate = false;
 
         LogonTrigger logonTrigger = new LogonTrigger();
         taskDefinition.Triggers.Add(logonTrigger);

--- a/ThreeFingerDragOnWindows/utils/StartupManager.cs
+++ b/ThreeFingerDragOnWindows/utils/StartupManager.cs
@@ -28,6 +28,7 @@ public static class StartupManager {
         taskDefinition.Settings.IdleSettings.StopOnIdleEnd = false;
         taskDefinition.Settings.ExecutionTimeLimit = TimeSpan.Zero;
         taskDefinition.Settings.AllowHardTerminate = false;
+        taskDefinition.Settings.Priority = ProcessPriorityClass.High;
 
         LogonTrigger logonTrigger = new LogonTrigger();
         taskDefinition.Triggers.Add(logonTrigger);


### PR DESCRIPTION
This tool is awesome❤️

After months of usage, I have noticed a few issues.
- The tool may accidentally stop when my laptop is unplugged from the power supply.
- The tool may accidentally stop when the system has been up for days.
- When the processor load is heavy, it can be sluggish in response.

I looked into it by myself, finding that those problems would only happen when running as administrator + run at startup, so this is likely caused by a misconfigured scheduler task. Further digging into it, I found that there was something wrong with the current scheduler task configuration.

![Screenshot 2024-03-27 154225](https://github.com/ClementGre/ThreeFingerDragOnWindows/assets/24606814/ac79d527-6907-42e3-abd8-71ea72e07bed)

![Screenshot 2024-03-27 154313](https://github.com/ClementGre/ThreeFingerDragOnWindows/assets/24606814/5224b6b7-6b7f-46c5-8d5a-cab696e963f1)

And the task started by the task scheduler seems to run at a lower priority, which can be easily preempted by normal tasks.

![Screenshot 2024-03-27 154400](https://github.com/ClementGre/ThreeFingerDragOnWindows/assets/24606814/6e2256b9-1ffc-4f0b-b668-3b696b1e5a69)

All of these issues are caused by the default value in the TaskScheduler library, what we all need is to add a few lines of code to explicitly configure those settings, and everything would work fine.

Aside from my issues, this may also fix #34 #43 .

