### PR TITLE
Add max distance between fingers setting to reject accidental drags

### DIFF
--- a/ThreeFingerDragOnWindows/settings/SettingsData.cs
+++ b/ThreeFingerDragOnWindows/settings/SettingsData.cs
@@ -69,6 +69,7 @@ public class SettingsData{
 
     public int ThreeFingerDragStartThreshold { get; set; } = 100;
     public int ThreeFingerDragStopThreshold { get; set; } = 10;
+    public int ThreeFingerDragMaxFingersDistance { get; set; } = 0; // 0 = disabled. Max allowed pairwise distance between fingers to start a drag.
    
     // Other settings
 

--- a/ThreeFingerDragOnWindows/settings/ThreeFingerDragSettings.xaml
+++ b/ThreeFingerDragOnWindows/settings/ThreeFingerDragSettings.xaml
@@ -210,6 +210,27 @@
                                SpinButtonPlacementMode="Compact" />
                 </StackPanel>
             </wuc:SettingsCard>
+            <wuc:SettingsCard
+                HeaderIcon="{wuc:FontIcon FontFamily={StaticResource SymbolThemeFontFamily}, Glyph=&#xE815;}"
+                Header="Maximum distance between fingers"
+                Description="The farthest allowed distance between any two fingers. Two effects: 1) With 3 fingers, the drag won't start if they are spread farther apart than this (e.g. one thumb on the left + two fingers on the right while typing). 2) With 4 fingers, if three of them stay within this distance and one is farther away (e.g. an accidental thumb + a real three-finger drag), the far finger is treated as an accidental touch and ignored, so the drag still works. Set to 0 to disable. Check the logs (maxPairDist) to find a suitable value.">
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Spacing="10">
+                    <Slider MinWidth="150"
+                            StepFrequency="1"
+                            Maximum="2000"
+                            Minimum="0"
+                            Value="{x:Bind MaxFingersDistanceProperty, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <NumberBox MinWidth="80"
+                               Value="{x:Bind MaxFingersDistanceProperty, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Minimum="0"
+                               Maximum="10000"
+                               SmallChange="10"
+                               LargeChange="100"
+                               SpinButtonPlacementMode="Compact" />
+                </StackPanel>
+            </wuc:SettingsCard>
 
             <Expander
                 IsExpanded="False"

--- a/ThreeFingerDragOnWindows/settings/ThreeFingerDragSettings.xaml.cs
+++ b/ThreeFingerDragOnWindows/settings/ThreeFingerDragSettings.xaml.cs
@@ -117,4 +117,13 @@ public sealed partial class ThreeFingerDragSettings : INotifyPropertyChanged{
             }
         }
     }
+    public int MaxFingersDistanceProperty {
+        get{ return App.SettingsData.ThreeFingerDragMaxFingersDistance; }
+        set{
+            if(App.SettingsData.ThreeFingerDragMaxFingersDistance != value){
+                App.SettingsData.ThreeFingerDragMaxFingersDistance = value;
+                OnPropertyChanged(nameof(MaxFingersDistanceProperty));
+            }
+        }
+    }
 }

--- a/ThreeFingerDragOnWindows/threefingerdrag/ThreeFingerDrag.cs
+++ b/ThreeFingerDragOnWindows/threefingerdrag/ThreeFingerDrag.cs
@@ -30,6 +30,21 @@ public class ThreeFingerDrag{
         bool hasFingersReleased = elapsed > RELEASE_FINGERS_THRESHOLD_MS;
         Logger.Log("TFD: " + string.Join(", ", oldContacts.Select(c => c.ToString())) + " | " +
                    string.Join(", ", contacts.Select(c => c.ToString())) + " | " + elapsed);
+
+        // Outlier rejection: when exactly 4 fingers are present and the max-distance threshold is
+        // set, check if one finger is an accidental touch (e.g. a thumb while typing) far from a
+        // compact trio. If so, drop the outlier so the remaining 3 fingers can drive the drag.
+        // oldContacts and contacts are filtered with the same rule so AreContactsIdsCommons keeps
+        // returning true (lengths stay equal and the same physical finger is dropped on both sides).
+        if(oldContacts.Length == 4 && contacts.Length == 4 &&
+           App.SettingsData.ThreeFingerDragMaxFingersDistance > 0){
+            oldContacts = TryRejectOutlier(oldContacts, App.SettingsData.ThreeFingerDragMaxFingersDistance, out _);
+            contacts = TryRejectOutlier(contacts, App.SettingsData.ThreeFingerDragMaxFingersDistance, out bool rejected);
+            if(rejected){
+                Logger.Log("    rejected 1 outlier finger (1+3 -> 3)");
+            }
+        }
+
         bool areContactsIdsCommons = FingerCounter.AreContactsIdsCommons(oldContacts, contacts);
 
         (_, Point longestDistDelta, float longestDist2D) =
@@ -38,11 +53,20 @@ public class ThreeFingerDrag{
                 int originalFingersCount) =
             _fingerCounter.CountMovingFingers(currentDevice, contacts, areContactsIdsCommons, longestDist2D, hasFingersReleased);
 
+        // Max pairwise distance between fingers on the current frame. Used to reject drags started
+        // by fingers spread far apart (e.g. a thumb resting on the left while typing + two fingers on the right).
+        float maxPairDist = App.SettingsData.ThreeFingerDragMaxFingersDistance > 0
+            ? GetMaxPairwiseDistance(contacts)
+            : 0;
+        bool areFingersTooFar = maxPairDist > 0 &&
+                                maxPairDist > App.SettingsData.ThreeFingerDragMaxFingersDistance;
+
         Logger.Log("    fingers: " + fingersCount + ", original: " + originalFingersCount + ", moving: " +
-                   shortDelayMovingFingersCount + "/" + longDelayMovingFingersCount + ", dist: " + longestDist2D);
+                   shortDelayMovingFingersCount + "/" + longDelayMovingFingersCount + ", dist: " + longestDist2D +
+                   ", maxPairDist: " + maxPairDist + (areFingersTooFar ? " (too far)" : ""));
 
         if(fingersCount >= 3 && areContactsIdsCommons && longDelayMovingFingersCount == 3 &&
-           originalFingersCount == 3 && !_isDragging){
+           originalFingersCount == 3 && !areFingersTooFar && !_isDragging){
             // Start dragging
             _isDragging = true;
             Logger.Log("    START DRAG, click down");
@@ -105,5 +129,57 @@ public class ThreeFingerDrag{
         return App.SettingsData.ThreeFingerDragAllowReleaseAndRestart
             ? Math.Max(App.SettingsData.ThreeFingerDragReleaseDelay, RELEASE_FINGERS_THRESHOLD_MS)
             : RELEASE_FINGERS_THRESHOLD_MS;
+    }
+
+    /// <summary>
+    /// Returns the largest distance between any two contacts on the current frame.
+    /// Used to detect fingers spread too far apart (e.g. an accidental thumb while typing).
+    /// </summary>
+    private static float GetMaxPairwiseDistance(TouchpadContact[] contacts){
+        float max = 0;
+        for(int i = 0; i < contacts.Length; i++){
+            for(int j = i + 1; j < contacts.Length; j++){
+                float d = contacts[i].GetDist2D(contacts[j]);
+                if(d > max) max = d;
+            }
+        }
+        return max;
+    }
+
+    /// <summary>
+    /// When exactly 4 contacts are present, find the single outlier (the finger far from a
+    /// compact trio) and return the remaining 3. Only rejects when the outlier is farther than
+    /// <paramref name="threshold"/> from ALL of the other three, which themselves must all be
+    /// within <paramref name="threshold"/> of each other (a true 1+3 split). A normal 4-finger
+    /// gesture has no fully-compact trio, so it is left untouched.
+    /// </summary>
+    private static TouchpadContact[] TryRejectOutlier(TouchpadContact[] contacts, float threshold, out bool rejected){
+        rejected = false;
+        if(contacts.Length != 4) return contacts;
+
+        for(int i = 0; i < 4; i++){
+            // Build the trio of the other three contacts.
+            var trio = new TouchpadContact[3];
+            int t = 0;
+            for(int j = 0; j < 4; j++) if(j != i) trio[t++] = contacts[j];
+
+            // The trio must be compact (all pairwise distances <= threshold).
+            if(GetMaxPairwiseDistance(trio) > threshold) continue;
+
+            // i must be far from every member of the trio (> threshold).
+            bool farFromAll = true;
+            for(int j = 0; j < 4; j++){
+                if(j == i) continue;
+                if(contacts[i].GetDist2D(contacts[j]) <= threshold){
+                    farFromAll = false;
+                    break;
+                }
+            }
+            if(farFromAll){
+                rejected = true;
+                return trio;
+            }
+        }
+        return contacts;
     }
 }


### PR DESCRIPTION
Adds a 'Maximum distance between fingers' setting (Three Finger Drag tab) that uses one threshold to prevent accidental three-finger drags caused by a thumb/palm resting on the touchpad while typing.

Two cases handled:
- 3 fingers spread too far apart (1 thumb + 2 fingers): drag is not started.
- 4 fingers with an outlier (1 accidental thumb + 3 real fingers): the far contact is detected and ignored, so the drag still works with the remaining three.

Defaults to 0 (disabled) - existing behaviour unchanged, no settings version bump. A maxPairDist value is logged to help choose a suitable value. Outlier rejection only handles the 4-finger (1+3) case; 5+ fingers keep original behaviour.

Files: SettingsData.cs (new property), ThreeFingerDrag.cs (GetMaxPairwiseDistance + TryRejectOutlier helpers, logging, outlier rejection at top of OnTouchpadContact), ThreeFingerDragSettings.xaml(.cs) (new settings card), README.md (feature docs + CLI MSIX build instructions). Built and verified locally (.NET 10, x64 MSIX).